### PR TITLE
Merge upstream changes for 2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+lib/syck.bundle
+pkg
+tmp

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -34,8 +34,8 @@ lib/syck/tag.rb
 lib/syck/types.rb
 lib/syck/yamlnode.rb
 lib/syck/ypath.rb
+lib/yaml/engine_manager.rb
 lib/yaml/syck.rb
-test/helper.rb
 test/test_array.rb
 test/test_boolean.rb
 test/test_class.rb

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -18,7 +18,6 @@ ext/syck/syck.h
 ext/syck/token.c
 ext/syck/yaml2byte.c
 ext/syck/yamlbyte.h
-lib/syck.bundle
 lib/syck.rb
 lib/syck/baseemitter.rb
 lib/syck/basenode.rb

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require 'rubygems'
 require 'hoe'
 
 Hoe.plugins.delete :rubyforge
-Hoe.plugin :minitest
 Hoe.plugin :gemspec # `gem install hoe-gemspec`
 Hoe.plugin :git     # `gem install hoe-git`
 

--- a/ext/syck/rubyext.c
+++ b/ext/syck/rubyext.c
@@ -28,7 +28,7 @@ typedef struct RVALUE {
     /*struct RString string;*/
     struct RArray  array;
     /*struct RRegexp regexp;*/
-    struct RHash   hash;
+    /*struct RHash   hash;*/
     /*struct RData   data;*/
     struct RStruct rstruct;
     /*struct RBignum bignum;*/

--- a/lib/syck.rb
+++ b/lib/syck.rb
@@ -7,7 +7,16 @@
 #
 
 require 'yaml/syck'
-require File.expand_path('../yaml/engine_manager', __FILE__)
+if defined?(YAML::ENGINE)
+    require File.expand_path('../yaml/engine_manager', __FILE__)
+else
+    Object.class_eval <<-eorb, __FILE__, __LINE__ + 1
+        remove_const 'YAML'
+        YAML = Syck
+        remove_method :to_yaml
+        alias :to_yaml :syck_to_yaml
+    eorb
+end
 
 # == YAML
 #

--- a/lib/syck.rb
+++ b/lib/syck.rb
@@ -11,7 +11,7 @@ if defined?(YAML::ENGINE)
     require File.expand_path('../yaml/engine_manager', __FILE__)
 else
     Object.class_eval <<-eorb, __FILE__, __LINE__ + 1
-        remove_const 'YAML'
+        remove_const 'YAML' if defined? YAML
         YAML = Syck
         remove_method :to_yaml
         alias :to_yaml :syck_to_yaml

--- a/lib/syck/constants.rb
+++ b/lib/syck/constants.rb
@@ -6,7 +6,7 @@ module Syck
 	#
 	# Constants
 	#
-	VERSION = '1.0.0'
+	VERSION = '1.0.2'
 	SUPPORTED_YAML_VERSIONS = ['1.0']
 
 	#

--- a/lib/syck/constants.rb
+++ b/lib/syck/constants.rb
@@ -6,7 +6,7 @@ module Syck
 	#
 	# Constants
 	#
-	VERSION = '1.0.3'
+	VERSION = '1.0.4'
 	SUPPORTED_YAML_VERSIONS = ['1.0']
 
 	#

--- a/lib/syck/constants.rb
+++ b/lib/syck/constants.rb
@@ -6,7 +6,7 @@ module Syck
 	#
 	# Constants
 	#
-	VERSION = '1.0.4'
+	VERSION = '1.0.5'
 	SUPPORTED_YAML_VERSIONS = ['1.0']
 
 	#

--- a/lib/syck/constants.rb
+++ b/lib/syck/constants.rb
@@ -6,7 +6,7 @@ module Syck
 	#
 	# Constants
 	#
-	VERSION = '1.0.2'
+	VERSION = '1.0.3'
 	SUPPORTED_YAML_VERSIONS = ['1.0']
 
 	#

--- a/syck.gemspec
+++ b/syck.gemspec
@@ -3,7 +3,7 @@
 require 'time'
 Gem::Specification.new do |s|
   s.name = "syck"
-  s.version = "1.0.1"
+  s.version = "1.0.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Aaron Patterson", "Mat Brown"]
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.extensions = ["ext/syck/extconf.rb"]
   s.extra_rdoc_files = ["CHANGELOG.rdoc", "Manifest.txt", "README.rdoc", "CHANGELOG.rdoc", "README.rdoc"]
   s.files = Dir["[A-Z]*", "ext/**/*", "lib/**/*.rb", "test/**/*.rb"]
-  s.homepage = "http://github.com/tenderlove/syck"
+  s.homepage = "https://github.com/RapGenius/syck"
   s.rdoc_options = ["--main", "README.rdoc"]
   s.require_paths = ["lib"]
   s.required_ruby_version = Gem::Requirement.new(">= 2.0.0")

--- a/syck.gemspec
+++ b/syck.gemspec
@@ -3,7 +3,7 @@
 require 'time'
 Gem::Specification.new do |s|
   s.name = "syck"
-  s.version = "1.0.2"
+  s.version = "1.0.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Aaron Patterson", "Mat Brown"]

--- a/syck.gemspec
+++ b/syck.gemspec
@@ -3,7 +3,7 @@
 require 'time'
 Gem::Specification.new do |s|
   s.name = "syck"
-  s.version = "1.0.4"
+  s.version = "1.0.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Aaron Patterson", "Mat Brown"]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,2 @@
+require 'test/unit'
+require 'syck'

--- a/test/test_struct.rb
+++ b/test/test_struct.rb
@@ -9,7 +9,7 @@ class StructWithIvar < Struct.new(:foo)
 end
 
 module Syck
-  class TestStruct < MiniTest::Unit::TestCase
+  class TestStruct < Test::Unit::TestCase
     def test_roundtrip
       thing = StructWithIvar.new('bar')
       struct = Syck.load(Syck.dump(thing))


### PR DESCRIPTION
@Sirupsen /cc: @jstorimer

For Rubby 2.2.0 compatibility, brings in everything from upstream. Replaces #1.
